### PR TITLE
[Docs] removed duplicated word

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please check out the [issue queue](https://github.com/Coders-Evoke-Community/sup
      
       
 ## Steps to join The Coders Evoke org in Github
-1. Go to the [Support Repo](https://github.com/Coders-Evoke-Community/support)
+1. Go to the [Support Repository](https://github.com/Coders-Evoke-Community/support)
 2. Click on issue tab and then create an issue with the template **Invite me to the org**.
 3. That's it you'll recieve an mail invitation to join our org in no time . 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please check out the [issue queue](https://github.com/Coders-Evoke-Community/sup
      
       
 ## Steps to join The Coders Evoke org in Github
-1. Go to the support repo [Support Repo](https://github.com/Coders-Evoke-Community/support)
+1. Go to the [Support Repo](https://github.com/Coders-Evoke-Community/support)
 2. Click on issue tab and then create an issue with the template **Invite me to the org**.
 3. That's it you'll recieve an mail invitation to join our org in no time . 
 


### PR DESCRIPTION
Support Repo had been included twice. The hyperlink text makes it clear that the link redirects to the support repository!